### PR TITLE
<video> tag controls fixes on iOS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/) and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
-## [1.0.1] - 2018-01-01
+## [1.0.1] - 2018-10-02
 ### Fixed
 - On iOS there is a workaround executed that makes the <video> element always being rendered on top of the Cliplister container. It's needed since Cliplister doesn't render its own controls on iOS, but the container which usually contains them is rendered on top of the <video> element which makes the natives controls not reachable for user. It happens however only starting from second render of the page containing Cliplister video.
 - Periodical exceptions thrown by Cliplister library (JSON parsing issue) caused by obsolete `slot` property passed to the `Cliplister.Viewer`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,10 +5,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/) and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+## [1.0.1] - 2018-01-01
+### Fixed
+- On iOS there is a workaround executed that makes the <video> element always being rendered on top of the Cliplister container. It's needed since Cliplister doesn't render its own controls on iOS, but the container which usually contains them is rendered on top of the <video> element which makes the natives controls not reachable for user. It happens however only starting from second render of the page containing Cliplister video.
+- Periodical exceptions thrown by Cliplister library (JSON parsing issue) caused by obsolete `slot` property passed to the `Cliplister.Viewer`.
+### Removed
+- Removed `slot` extension config and it's implementation. Change is backwards compatible. This property was obsolete and causing troubles on live. Currently is ignored if set by extension config.
+
 ## [1.0.0] - 2018-09-28
 ### Added
 - First, simple implementation that shows the video player before the product description.
 
 
-[Unreleased]: https://github.com/shopgate/ext-cliplister/compare/v1.0.0...HEAD
+[Unreleased]: https://github.com/shopgate/ext-cliplister/compare/v1.0.1...HEAD
+[1.0.1]: https://github.com/shopgate/ext-cliplister/compare/v1.0.0...v1.0.1
 [1.0.0]: https://github.com/shopgate/ext-cliplister/compare/v0.0.1...v1.0.0

--- a/extension-config.json
+++ b/extension-config.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.0.0",
+  "version": "1.0.1",
   "id": "@shopgate/cliplister",
   "components": [
     {

--- a/extension-config.json
+++ b/extension-config.json
@@ -33,16 +33,6 @@
         "type": "text",
         "label": "Video search key: (EAN or PRODUCT_NUMBER)"
       }
-    },
-    "slot": {
-      "type": "admin",
-      "destination": "both",
-      "default": 0,
-      "params": {
-        "required": false,
-        "type": "number",
-        "label": "Slot"
-      }
     }
   }
 }

--- a/frontend/helpers/getNavigator.js
+++ b/frontend/helpers/getNavigator.js
@@ -1,0 +1,6 @@
+/**
+ * Navigator as a module, since it's not possible (or difficult) to mock global.navigator
+ * with jest.
+ * @returns {Object}
+ */
+export default () => navigator;

--- a/frontend/helpers/getNavigator.spec.js
+++ b/frontend/helpers/getNavigator.spec.js
@@ -1,0 +1,7 @@
+import getNavigator from './getNavigator';
+
+describe('navigator', () => {
+  it('should be an object', () => {
+    expect(typeof getNavigator()).toBe('object');
+  });
+});

--- a/frontend/helpers/isiOSPlatform.js
+++ b/frontend/helpers/isiOSPlatform.js
@@ -1,0 +1,3 @@
+import getNavigator from './getNavigator';
+
+export default () => getNavigator().vendor.includes('Apple');

--- a/frontend/helpers/isiOSPlatform.spec.js
+++ b/frontend/helpers/isiOSPlatform.spec.js
@@ -1,0 +1,23 @@
+import isiOSPlatform from './isiOSPlatform';
+
+let mockedNavigator = {
+  vendor: 'Something else',
+};
+
+jest.mock('./getNavigator', () => () => mockedNavigator);
+
+describe('isiOSPlatform', () => {
+  it('should return false for Android', () => {
+    mockedNavigator = {
+      vendor: 'Something else.',
+    };
+    expect(isiOSPlatform()).toBe(false);
+  });
+
+  it('should return true for ios', () => {
+    mockedNavigator = {
+      vendor: 'Apple Computer, Inc.',
+    };
+    expect(isiOSPlatform()).toBe(true);
+  });
+});

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "shopgate-cliplister",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Shopgate Cliplister implementation for Shopgate Connect",
   "main": "index.js",
   "scripts": {

--- a/frontend/portals/ProductVideo/component.jsx
+++ b/frontend/portals/ProductVideo/component.jsx
@@ -39,11 +39,10 @@ class ProductVideo extends Component {
   constructor(props) {
     super(props);
 
-    const { customerNumber, assetType, slot } = getConfig();
+    const { customerNumber, assetType } = getConfig();
     // Keeping this here for testing purposes.
     this.customerNumber = customerNumber;
     this.assetType = assetType;
-    this.slot = slot;
   }
 
   /**
@@ -71,7 +70,6 @@ class ProductVideo extends Component {
     logger.log('Shopgate Cliplister: trying to init with params', {
       customerNumber: this.customerNumber,
       assetType: this.assetType,
-      slot: this.slot,
       assetKey,
     });
 
@@ -81,7 +79,6 @@ class ProductVideo extends Component {
           customerNumber={this.customerNumber}
           assetKey={assetKey}
           assetType={this.assetType}
-          slot={this.slot}
         />
       </div>
     );

--- a/frontend/portals/ProductVideo/component.spec.jsx
+++ b/frontend/portals/ProductVideo/component.spec.jsx
@@ -3,7 +3,6 @@ import { mount } from 'enzyme';
 import MockedReactCliplister from '../../vendor/react-cliplister/mock';
 
 const mockedCustomerNumber = 1000;
-const mockedSlot = 1;
 let mockedAssetType = 'EAddN';
 
 jest.mock('../../config', () => ({
@@ -11,7 +10,6 @@ jest.mock('../../config', () => ({
     return mockedAssetType;
   },
   customerNumber: mockedCustomerNumber,
-  slot: mockedSlot,
 }));
 
 const mockedLoggerLog = jest.fn();
@@ -54,7 +52,6 @@ describe('ProductVideo', () => {
       customerNumber: mockedCustomerNumber,
       assetKey: assetType === 'EAN' ? 'EAN-NUMBER' : 'productId',
       assetType: mockedAssetType,
-      slot: mockedSlot,
     });
     expect(mockedLoggerLog).toHaveBeenCalled();
     expect(mockedLoggerWarn).not.toHaveBeenCalled();

--- a/frontend/vendor/cliplister/viewer/index.spec.js
+++ b/frontend/vendor/cliplister/viewer/index.spec.js
@@ -1,6 +1,8 @@
 import getCliplister from './index';
 
 const mockedCliplister = {};
+let promise;
+
 describe('Cliplister Viewer - dependency injection', () => {
   const mockedCreateElement = jest.fn();
   beforeAll(() => {
@@ -21,15 +23,17 @@ describe('Cliplister Viewer - dependency injection', () => {
   it('should inject script', (done) => {
     // Setting up a flag that tells us that promise was not fulfilled (as expected).
     let promiseDone = false;
-    // Call the function to start everything.
-    getCliplister()
-      .then((value) => {
-        promiseDone = true;
-        // The returned value should be a reference of what we defined in previous tick.
-        expect(value).toBe(mockedCliplister);
+    // Call the function to start everything. Keep the promise ref for later test.
+    promise = getCliplister();
 
-        done();
-      });
+    promise.then((value) => {
+      promiseDone = true;
+      // The returned value should be a reference of what we defined in previous tick.
+      expect(value).toBe(mockedCliplister);
+
+      done();
+    });
+
     // There should be immediate script injection.
     expect(mockedCreateElement).toHaveBeenCalled();
     expect(document.body.appendChild).toHaveBeenCalled();
@@ -43,5 +47,11 @@ describe('Cliplister Viewer - dependency injection', () => {
         value: mockedCliplister,
       });
     }, 0);
+  });
+
+  it('should return same promise as before', () => {
+    const secondPromise = getCliplister();
+
+    expect(promise === secondPromise).toBe(true);
   });
 });

--- a/frontend/vendor/react-cliplister/index.jsx
+++ b/frontend/vendor/react-cliplister/index.jsx
@@ -30,7 +30,6 @@ class ReactCliplister extends Component {
       typeProductNumber,
     ]).isRequired,
     customerNumber: PropTypes.number.isRequired,
-    slot: PropTypes.number,
   };
 
   /**
@@ -40,14 +39,6 @@ class ReactCliplister extends Component {
   static assetTypes = {
     EAN: typeEAN,
     PRODUCT_NUMBER: typeProductNumber,
-  };
-
-  /**
-   * Default props.
-   * @returns {Object}
-   */
-  static defaultProps = {
-    slot: 0,
   };
 
   /**
@@ -105,7 +96,6 @@ class ReactCliplister extends Component {
             width: '100%',
             aspectRatio: 'asset',
           },
-          slot: this.props.slot,
           plugins: {
             ClickableVideo: {
               layer: 1,

--- a/frontend/vendor/react-cliplister/index.jsx
+++ b/frontend/vendor/react-cliplister/index.jsx
@@ -2,6 +2,7 @@ import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { logger } from '@shopgate/pwa-core/helpers';
 import getCliplister from '../cliplister/viewer';
+import isiOSPlatform from '../../helpers/isiOSPlatform';
 
 const typeEAN = 'EAN'; // Cliplister id = 0 => Also, default identifier
 const typeProductNumber = 'PRODUCT_NUMBER'; // Cliplister id = 10000 => Custom identifier.
@@ -49,37 +50,6 @@ class ReactCliplister extends Component {
     this.viewer = undefined;
     this.namespace = `Cliplister-${Date.now()}-${Math.random()}`;
   }
-
-  /**
-   * The onPlay callback. It does two things:
-   * 1. Makes sure the <video> parent div is above the controls container. Otherwise on iOS it's
-   * impossible to use any native controls on second render, because the controls container has some
-   * js/css problem and constantly flickers on top of the video blocking user input.
-   * 2. Unmutes the video. This works around the issue that there is no "mute" button on ios native
-   * video element.
-   */
-  handlePlay = () => {
-    try {
-      this.viewer.unmute();
-      document.getElementById(this.namespace)
-        .querySelector('div.cliplister-viewer > div:last-child').style.zIndex = 1;
-    } catch (err) {
-      logger.error('HandlePlay error', err);
-    }
-  }
-
-  /**
-   * Cleans up after handlePlay workarounds.
-   */
-  handleStop = () => {
-    try {
-      this.viewer.mute();
-      document.getElementById(this.namespace)
-        .querySelector('div.cliplister-viewer > div:last-child').style.zIndex = 0;
-    } catch (err) {
-      logger.error('HandleStop error', err);
-    }
-  };
 
   /**
    * Prepares the viewer which injects the cliplister DOM into the namespaced container.
@@ -149,6 +119,45 @@ class ReactCliplister extends Component {
     this.viewer.stop();
     this.viewer.destroy();
   }
+
+  /**
+   * The onPlay callback. It does two things:
+   * 1. Makes sure the <video> parent div is above the controls container. Otherwise on iOS it's
+   * impossible to use any native controls on second render, because the controls container has some
+   * js/css problem and constantly flickers on top of the video blocking user input.
+   * 2. Unmutes the video. This works around the issue that there is no "mute" button on ios native
+   * video element.
+   */
+  handlePlay = () => {
+    try {
+      // Non iOS devices show Cliplister controls. Workaround only for iOS.
+      if (!isiOSPlatform()) {
+        return;
+      }
+      this.viewer.unmute();
+      document.getElementById(this.namespace)
+        .querySelector('div.cliplister-viewer > div:last-child').style.zIndex = 1;
+    } catch (err) {
+      logger.error('HandlePlay error', err);
+    }
+  }
+
+  /**
+   * Cleans up after handlePlay workarounds.
+   */
+  handleStop = () => {
+    try {
+      // Non iOS devices show Cliplister controls. Workaround only for iOS.
+      if (!isiOSPlatform()) {
+        return;
+      }
+      this.viewer.mute();
+      document.getElementById(this.namespace)
+        .querySelector('div.cliplister-viewer > div:last-child').style.zIndex = 0;
+    } catch (err) {
+      logger.error('HandleStop error', err);
+    }
+  };
 
   /**
    * Renders.

--- a/frontend/vendor/react-cliplister/index.spec.jsx
+++ b/frontend/vendor/react-cliplister/index.spec.jsx
@@ -26,6 +26,9 @@ jest.mock('@shopgate/pwa-core/helpers', () => ({
   },
 }));
 
+let mockedIsiOS = true;
+jest.mock('../../helpers/isiOSPlatform', () => () => mockedIsiOS);
+
 describe('ReactCliplister', () => {
   describe('Optimistic workflow', () => {
     beforeAll(() => {
@@ -39,8 +42,11 @@ describe('ReactCliplister', () => {
             stop: () => mockedViewerStop(),
             mute: () => mockedViewerMute(),
             unmute: () => mockedViewerUnmute(),
+            // eslint-disable-next-line no-shadow
             onPause: (...args) => mockedViewerOnPause(...args),
+            // eslint-disable-next-line no-shadow
             onStop: (...args) => mockedViewerOnStop(...args),
+            // eslint-disable-next-line no-shadow
             onPlay: (...args) => mockedViewerOnPlay(...args),
           };
         },
@@ -49,7 +55,9 @@ describe('ReactCliplister', () => {
 
     beforeEach(() => {
       mockedLoggerError.mockClear();
-    })
+      mockedViewerMute.mockClear();
+      mockedViewerUnmute.mockClear();
+    });
 
     // Order matters in this test!
     let component;
@@ -79,6 +87,17 @@ describe('ReactCliplister', () => {
       expect(mockedViewerMute).toHaveBeenCalled();
 
       expect(mockedLoggerError).toHaveBeenCalledTimes(2);
+    });
+
+    it('should NOT manipulate video when platform is not iOS', () => {
+      const instance = component.instance();
+      mockedIsiOS = false;
+      instance.handlePlay();
+      expect(mockedViewerUnmute).not.toHaveBeenCalled();
+      instance.handleStop();
+      expect(mockedViewerMute).not.toHaveBeenCalled();
+
+      expect(mockedLoggerError).not.toHaveBeenCalled();
     });
 
     it('should handle Viewer lifecycle', () => {

--- a/frontend/vendor/react-cliplister/index.spec.jsx
+++ b/frontend/vendor/react-cliplister/index.spec.jsx
@@ -59,7 +59,6 @@ describe('ReactCliplister', () => {
           customerNumber={100}
           assetKey="ASSET_KEY"
           assetType={ReactCliplister.assetTypes.EAN}
-          slot={1}
         />
       ));
       const namespaceArr = component.find('div').props().id.split('-');
@@ -89,7 +88,6 @@ describe('ReactCliplister', () => {
           'ASSET_KEY',
         ],
         keyType: 0,
-        slot: 1,
       }));
 
       // Binds to <video> callbacks.

--- a/frontend/vendor/react-cliplister/mock.jsx
+++ b/frontend/vendor/react-cliplister/mock.jsx
@@ -19,13 +19,6 @@ class MockedReactCliplister extends ReactCliplister {
   componentDidMount() {
     // Do nothing.
   }
-
-  /**
-   * Override of default componentWillUnmount.
-   */
-  componentWillUnmount() {
-    // Do nothing.
-  }
 }
 
 export default MockedReactCliplister;


### PR DESCRIPTION
# Pull Request Template

## Description

Workaround for ios <video> tag being covered by Cliplister plugins container (no user interaction possible).

## Type of change

- [x] Bug fix
- Added z-index=1 when video is playing to avoid Cliplister plugins container being on top of the video on iOS.
- Removed deprecated "slot" prop. It's not used in current library and sometimes causes exceptions.
- [ ] New feature
- [x] This change requires a documentation update

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I updated the CHANGELOG.md